### PR TITLE
Added smart_list support for *

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -12,7 +12,7 @@
 	{ "keys": ["enter"], "command": "smart_list", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+*]|\\d+\\.+)\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+\\**]|\\d+\\.+)\\s+" }
 		]
 	},
 	{ "keys": ["enter"], "command": "smart_list", "context":

--- a/smart_list.py
+++ b/smart_list.py
@@ -8,8 +8,8 @@ import sublime_plugin
 
 
 ORDER_LIST_PATTERN = re.compile(r"(\s*)(\d+)(\.\s+)\S+")
-UNORDER_LIST_PATTERN = re.compile(r"(\s*[-+*]+)(\s+)\S+")
-EMPTY_LIST_PATTERN = re.compile(r"(\s*([-+*]|\d+\.+))\s+$")
+UNORDER_LIST_PATTERN = re.compile(r"(\s*[-+\**]+)(\s+)\S+")
+EMPTY_LIST_PATTERN = re.compile(r"(\s*([-+\**]|\d+\.+))\s+$")
 
 
 class SmartListCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Numbered lists, `+` and `-` all work properly.

Unfortunately, `*` does not.  

Looks like the regexes from https://github.com/demon386/SmartMarkdown/pull/5 are just a little off:
https://github.com/mhenry07/SmartMarkdown/commit/6f229aa8bc204680e8fee775e3515fd416039a4a
