### PR TITLE
Nicer folding

### DIFF
--- a/Add Line SmartMarkdown Heading.sublime-macro
+++ b/Add Line SmartMarkdown Heading.sublime-macro
@@ -1,0 +1,5 @@
+[
+    {"command": "move_to", "args": {"to": "hardeol"}},
+    {"command": "move_to", "args": {"to": "eol"}},
+    {"command": "insert", "args": {"characters": "\n"}}
+]

--- a/Add Line SmartMarkdown Heading.sublime-macro
+++ b/Add Line SmartMarkdown Heading.sublime-macro
@@ -1,5 +1,0 @@
-[
-    {"command": "move_to", "args": {"to": "hardeol"}},
-    {"command": "move_to", "args": {"to": "eol"}},
-    {"command": "insert", "args": {"characters": "\n"}}
-]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -23,8 +23,7 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
     },
-    { "keys": ["ctrl+enter"], "command": "run_macro_file",
-      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+    { "keys": ["ctrl+enter"], "command": "smart_new_line", "context":
         [
             { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
         ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -22,5 +22,11 @@
         [
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
+    },
+    { "keys": ["ctrl+enter"], "command": "run_macro_file",
+      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
+        ]
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -23,8 +23,7 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
     },
-    { "keys": ["ctrl+enter"], "command": "run_macro_file",
-      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+    { "keys": ["ctrl+enter"], "command": "smart_new_line", "context":
         [
             { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
         ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -22,5 +22,11 @@
         [
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
+    },
+    { "keys": ["ctrl+enter"], "command": "run_macro_file",
+      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
+        ]
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -23,8 +23,7 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
     },
-    { "keys": ["ctrl+enter"], "command": "run_macro_file",
-      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+    { "keys": ["ctrl+enter"], "command": "smart_new_line", "context":
         [
             { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
         ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -22,5 +22,11 @@
         [
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown" }
         ]
+    },
+    { "keys": ["ctrl+enter"], "command": "run_macro_file",
+      "args": {"file": "res://Packages/SmartMarkdown/Add Line SmartMarkdown Heading.sublime-macro"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "markup.heading.markdown" }
+        ]
     }
 ]

--- a/headline.py
+++ b/headline.py
@@ -9,7 +9,11 @@ Terminologies
 
 import re
 import sublime
-from .utilities import is_region_void
+
+try:
+    from .utilities import is_region_void
+except ValueError:
+    from utilities import is_region_void
 
 MATCH_PARENT = 1   # Match headlines at the same or higher level
 MATCH_CHILD = 2    # Match headlines at the same or lower level

--- a/headline_move.py
+++ b/headline_move.py
@@ -8,8 +8,12 @@ The feature is borrowed from [Org-mode](http://org-mode.org).
 import sublime
 import sublime_plugin
 
-from . import headline
-from .utilities import is_region_void
+try:
+    from . import headline
+    from .utilities import is_region_void
+except ValueError:
+    import headline
+    from utilities import is_region_void
 
 
 class HeadlineMoveCommand(sublime_plugin.TextCommand):

--- a/smart_folding.py
+++ b/smart_folding.py
@@ -13,8 +13,12 @@ import re
 import sublime
 import sublime_plugin
 
-from . import headline
-from .utilities import is_region_void
+try:
+    from . import headline
+    from .utilities import is_region_void
+except ValueError:
+    import headline
+    from utilities import is_region_void
 
 
 HEADLINE_PATTERN = re.compile(r'^(#+)\s.*')

--- a/smart_folding.py
+++ b/smart_folding.py
@@ -29,15 +29,16 @@ class SmartNewLineCommand(sublime_plugin.TextCommand):
        Puts new line after folding mark if any.
     """
     def run(self, edit):
-        self.view.run_command("move_to", { "to": "hardeol"})
-        self.view.run_command("move_to", { "to": "eol"})
-        point = self.view.full_line(self.view.sel()[0])
-        if headline._is_region_folded(point.b + 1, self.view):
-            self.view.run_command("move_to", { "to": "eof"})
-            self.view.run_command("insert", {"characters": "\n"})
-        else:
-            self.view.run_command("insert", {"characters": "\n"})
-
+        points = []
+        for s in self.view.sel():
+            r = self.view.full_line(s)
+            if headline._is_region_folded(r.b + 1, self.view):
+                i = headline.region_of_content_of_headline_at_point(self.view, s.b)
+                points.append(i)
+            self.view.insert(edit, i.b, '\n')
+        self.view.sel().clear()
+        for p in points:
+            self.view.sel().add(p.b + 1)
 
 class SmartFoldingCommand(sublime_plugin.TextCommand):
     """Smart folding is used to fold / unfold headline at the point.

--- a/smart_folding.py
+++ b/smart_folding.py
@@ -65,7 +65,8 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
         if self.is_region_totally_folded(content_region):
             self.unfold_yet_fold_subheads(content_region, level)
         else:
-            self.view.fold(content_region)
+            self.view.fold(sublime.Region(sublime.Region.begin(content_region) - 1, \
+                                          sublime.Region.end(content_region)))
         return True
 
     def is_region_totally_folded(self, region):
@@ -90,7 +91,8 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
             child_content_region = headline.region_of_content_of_headline_at_point(self.view,
                                                                                    child_headline_region.a)
             if child_content_region is not None:
-                self.view.fold(child_content_region)
+                self.view.fold(sublime.Region(sublime.Region.begin(child_content_region) - 1, \
+                                              sublime.Region.end(child_content_region)))
                 search_start_point = child_content_region.b
             else:
                 search_start_point = child_headline_region.b
@@ -162,7 +164,8 @@ class GlobalFoldingCommand(SmartFoldingCommand):
                                                                      point)
             if not is_region_void(region):
                 point = region.b
-                self.view.fold(region)
+                self.view.fold(sublime.Region(sublime.Region.begin(region) - 1, \
+                                              sublime.Region.end(region)))
             region, level = headline.find_headline(self.view, point, \
                                                    headline.ANY_LEVEL,
                                                    True, \

--- a/smart_folding.py
+++ b/smart_folding.py
@@ -24,6 +24,21 @@ except ValueError:
 HEADLINE_PATTERN = re.compile(r'^(#+)\s.*')
 
 
+class SmartNewLineCommand(sublime_plugin.TextCommand):
+    """Changes behavior of default 'insert line after'
+       Puts new line after folding mark if any.
+    """
+    def run(self, edit):
+        self.view.run_command("move_to", { "to": "hardeol"})
+        self.view.run_command("move_to", { "to": "eol"})
+        point = self.view.full_line(self.view.sel()[0])
+        if headline._is_region_folded(point.b + 1, self.view):
+            self.view.run_command("move_to", { "to": "eof"})
+            self.view.run_command("insert", {"characters": "\n"})
+        else:
+            self.view.run_command("insert", {"characters": "\n"})
+
+
 class SmartFoldingCommand(sublime_plugin.TextCommand):
     """Smart folding is used to fold / unfold headline at the point.
 

--- a/smart_folding.py
+++ b/smart_folding.py
@@ -65,8 +65,7 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
         if self.is_region_totally_folded(content_region):
             self.unfold_yet_fold_subheads(content_region, level)
         else:
-            self.view.fold(sublime.Region(sublime.Region.begin(content_region) - 1, \
-                                          sublime.Region.end(content_region)))
+            self.view.fold(sublime.Region(content_region.a - 1, content_region.b))
         return True
 
     def is_region_totally_folded(self, region):
@@ -91,8 +90,7 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
             child_content_region = headline.region_of_content_of_headline_at_point(self.view,
                                                                                    child_headline_region.a)
             if child_content_region is not None:
-                self.view.fold(sublime.Region(sublime.Region.begin(child_content_region) - 1, \
-                                              sublime.Region.end(child_content_region)))
+                self.view.fold(sublime.Region(child_content_region.a - 1, child_content_region.b))
                 search_start_point = child_content_region.b
             else:
                 search_start_point = child_headline_region.b
@@ -164,8 +162,7 @@ class GlobalFoldingCommand(SmartFoldingCommand):
                                                                      point)
             if not is_region_void(region):
                 point = region.b
-                self.view.fold(sublime.Region(sublime.Region.begin(region) - 1, \
-                                              sublime.Region.end(region)))
+                self.view.fold(sublime.Region(region.a - 1, region.b))
             region, level = headline.find_headline(self.view, point, \
                                                    headline.ANY_LEVEL,
                                                    True, \

--- a/smart_table.py
+++ b/smart_table.py
@@ -10,7 +10,10 @@ Markdown itself doesn't support grid table, yet pandoc does.
 import sublime
 import sublime_plugin
 
-from . import table
+try:
+    from . import table
+except ValueError:
+    import table
 
 
 class SmartTable(sublime_plugin.TextCommand):

--- a/table.py
+++ b/table.py
@@ -14,7 +14,10 @@ import copy
 
 import sublime
 
-from . import utilities
+try:
+    from . import utilities
+except ValueError:
+    import utilities
 
 TABLE_PATTERN = re.compile(r"\s*\|")
 SEPARATOR_PATTERN = re.compile(r"\s*(\+[=-])")


### PR DESCRIPTION
This is a slightly half-baked attempt to address #12.

I've incorporated @vovkkk's code and improved the handling of Ctrl/Cmd+Enter, but it's still problematic in the following cases:
- When word wrap is on and the fold marker is on its own line.

```
# Heading 1
[...]
Et cetera
```
- There is only one heading and the rest of the document is folded.

```
# Heading 1[...]
```
