### PR TITLE
modifies smart_lists

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -12,7 +12,7 @@
 	{ "keys": ["enter"], "command": "smart_list", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+\\**]|\\d+\\.+)\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+\\**\\>\\|%]+|[(]?\\d+[.)]+)\\s+" }
 		]
 	},
 	{ "keys": ["enter"], "command": "smart_list", "context":

--- a/SmartMarkdown.sublime-settings
+++ b/SmartMarkdown.sublime-settings
@@ -7,5 +7,9 @@
     "pandoc_args": [],
     "pandoc_args_pdf": [],
     "pandoc_args_html": [],
-    "pandoc_args_docx": []
+    "pandoc_args_docx": [],
+
+    /* If true empty bullet will be converted into whitespaces when pressing enter,
+    if false empty bullet will be erased completely */
+    "empty_list_bullet": false
 }

--- a/smart_list.py
+++ b/smart_list.py
@@ -60,8 +60,15 @@ class SmartListCommand(sublime_plugin.TextCommand):
 
             match = NONLIST_PATTERN.match(before_point_content)
             if match:
-                insert_text = match.group(1) + match.group(2)
-                self.view.insert(edit, region.a, "\n" + insert_text)
+                current_line = self.view.line(region.a)
+                prev_line = self.view.line(current_line.a - 1)
+                empty_nonlist = match.group(1) + match.group(2)
+                if (self.view.substr(prev_line) == empty_nonlist) and (self.view.substr(current_line) == empty_nonlist):
+                    self.view.replace(edit, current_line, '')
+                    self.view.replace(edit, prev_line, '')
+                else:
+                    insert_text = match.group(1) + match.group(2)
+                    self.view.insert(edit, region.a, "\n" + insert_text)
                 break
 
             self.view.insert(edit, region.a, '\n')

--- a/smart_list.py
+++ b/smart_list.py
@@ -33,11 +33,15 @@ class SmartListCommand(sublime_plugin.TextCommand):
 
             match = EMPTY_LIST_PATTERN.match(before_point_content)
             if match:
-                insert_text = match.group(1) + \
-                              re.sub(r'\S', ' ', str(match.group(2))) + \
-                              match.group(3)
-                self.view.erase(edit, before_point_region)
-                self.view.insert(edit, line_region.a, insert_text)
+                settings = sublime.load_settings("SmartMarkdown.sublime-settings")
+                if settings.get("empty_list_bullet"):
+                    insert_text = match.group(1) + \
+                                  re.sub(r'\S', ' ', str(match.group(2))) + \
+                                  match.group(3)
+                    self.view.erase(edit, before_point_region)
+                    self.view.insert(edit, line_region.a, insert_text)
+                else:
+                    self.view.erase(edit, before_point_region)
                 break
 
             match = ORDER_LIST_PATTERN.match(before_point_content)
@@ -60,8 +64,7 @@ class SmartListCommand(sublime_plugin.TextCommand):
                 self.view.insert(edit, region.a, "\n" + insert_text)
                 break
 
-            self.view.insert(edit, region.a, '\n' + \
-                             re.sub(r'\S+\s*', '', before_point_content))
+            self.view.insert(edit, region.a, '\n')
         self.adjust_view()
 
     def adjust_view(self):

--- a/smart_list.py
+++ b/smart_list.py
@@ -60,7 +60,8 @@ class SmartListCommand(sublime_plugin.TextCommand):
                 self.view.insert(edit, region.a, "\n" + insert_text)
                 break
 
-            self.view.insert(edit, region.a, '\n')
+            self.view.insert(edit, region.a, '\n' + \
+                             re.sub(r'\S+\s*', '', before_point_content))
         self.adjust_view()
 
     def adjust_view(self):


### PR DESCRIPTION
adds non-lists patterns: 
- block quotes (>); 
- line block (|); 
- title block (%);

marker of ordered list may be enclosed in parentheses or followed by a single right-parentheses;
(optionally) list item may contain multiple paragraphs (i.e. empty list bullet is converted to whitespaces)

---

non-list pattern breaks after triple press enter, e.g.:

``` markdown
> This is a block quote.
> 
>
```

become:

``` markdown
> This is a block quote.


```
