### PR TITLE
Quick indent lists

### DIFF
--- a/Add Line with Smart List.sublime-macro
+++ b/Add Line with Smart List.sublime-macro
@@ -1,0 +1,4 @@
+[
+    {"command": "move_to", "args": {"to": "hardeol"}},
+    {"command": "smart_list"}
+]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -71,11 +71,13 @@
 	},
 	{ "keys": ["tab"], "command": "indent", "context":
 		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#\\.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 		]
 	},
 	{ "keys": ["shift+tab"], "command": "unindent", "context":
 		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#\\.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 			// Should we enable the following setting check?
 			// { "key": "setting.shift_tab_unindent", "operator": "equal", "operand": true }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -71,12 +71,12 @@
 	},
 	{ "keys": ["tab"], "command": "indent", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "markup.list" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z])[\\.\\)]|\\((\\d+|[A-z])\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 		]
 	},
 	{ "keys": ["shift+tab"], "command": "unindent", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "markup.list" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z])[\\.\\)]|\\((\\d+|[A-z])\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 			// Should we enable the following setting check?
 			// { "key": "setting.shift_tab_unindent", "operator": "equal", "operand": true }
 		]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -71,12 +71,12 @@
 	},
 	{ "keys": ["tab"], "command": "indent", "context":
 		[
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#\\.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 		]
 	},
 	{ "keys": ["shift+tab"], "command": "unindent", "context":
 		[
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#\\.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 			// Should we enable the following setting check?
 			// { "key": "setting.shift_tab_unindent", "operator": "equal", "operand": true }
 		]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -15,6 +15,12 @@
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+\\**]|\\d+\\.+)\\s+" }
 		]
 	},
+	{ "keys": ["ctrl+enter"], "command": "run_macro_file", "args": {"file": "res://Packages/SmartMarkdown/Add Line with Smart List.sublime-macro"}, "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-+\\**\\>\\|%]+|[(]?\\d+[.)]+)\\s+" }
+		]
+	},
 	{ "keys": ["enter"], "command": "smart_list", "context":
 		[
 		    { "key": "selector", "operator": "equal", "operand": "text.html.markdown" },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -72,6 +72,7 @@
 	{ "keys": ["tab"], "command": "indent", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" },
+			{ "key": "auto_complete_visible", "operator": "equal", "operand": false },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#\\.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 		]
 	},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -68,5 +68,17 @@
 			[
 				{"key": "selector", "operator": "equal", "operand": "text.html.markdown"}
 			]
+	},
+	{ "keys": ["tab"], "command": "indent", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "markup.list" }
+		]
+	},
+	{ "keys": ["shift+tab"], "command": "unindent", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "markup.list" },
+			// Should we enable the following setting check?
+			// { "key": "setting.shift_tab_unindent", "operator": "equal", "operand": true }
+		]
 	}
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -71,12 +71,12 @@
 	},
 	{ "keys": ["tab"], "command": "indent", "context":
 		[
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z])[\\.\\)]|\\((\\d+|[A-z])\\)|\\(\\@[\\w\\-]*\\))\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 		]
 	},
 	{ "keys": ["shift+tab"], "command": "unindent", "context":
 		[
-			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z])[\\.\\)]|\\((\\d+|[A-z])\\)|\\(\\@[\\w\\-]*\\))\\s+" }
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*([-\\+\\*]|#.|(\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)[\\.\\)]|\\((\\d+|[A-z]|[IVXLCDM]+|[ivxlcdm]+)\\)|\\(\\@[\\w\\-]*\\))\\s+" }
 			// Should we enable the following setting check?
 			// { "key": "setting.shift_tab_unindent", "operator": "equal", "operand": true }
 		]


### PR DESCRIPTION
I had to cherry pick through my devel branch. I hope this is everything :)
- Resolves #9.
- The regex looks for most of what Pandoc would consider valid. (See https://github.com/alehandrof/SmartMarkdown/commit/90953bf8eac5b4d6590f249e0af775c398783a0e for details.)
- @vovkkk had suggested I restrict the binding so that it doesn't fire inside code blocks. I haven't found this necessary, but if you decide otherwise, this is an easy fix.
- I have added the ability to use Ctrl+Enter to add new line with SmartList when in a list. I find this very useful, but YMMV. (https://github.com/alehandrof/SmartMarkdown/commit/b79c9ec35d50186fceca5a2b427f0b88148dcd9f)
