### PR TITLE
fixed a cross-platform issue with the os path separator

### DIFF
--- a/pandoc_render.py
+++ b/pandoc_render.py
@@ -76,7 +76,7 @@ class PandocRenderCommand(sublime_plugin.TextCommand):
         setting_path = self.setting.get("tex_path", [])
         for p in setting_path:
             if p not in os.environ["PATH"]:
-                os.environ["PATH"] += ":" + p
+                os.environ["PATH"] += os.pathsep + p
 
         try:
             # Use the current directory as working dir whenever possible


### PR DESCRIPTION
i had an issue on windows because the path separator was hard coded to a colon. on windows, the path separator is a semi-colon. i fixed by using the `os.pathsep` property.
