### PR TITLE
do not delete whitespace at beginning of cells

### DIFF
--- a/table.py
+++ b/table.py
@@ -104,7 +104,7 @@ def _convert_row_text_as_list(row_text):
     if match:
         lst = [match.group(1)]
 
-    return [i.strip() for i in lst]
+    return [re.sub("^ ","",i.rstrip()) for i in lst]
 
 
 def reformat_table_list(table):


### PR DESCRIPTION
Pandoc allows markdown, including code blocks, inside of grid tables. This is very frequently useful. However, the current implementation zaps all white space at the beginning of cells, ruining code indentation/formatting.

This pull request addresses [Issue #38](https://github.com/demon386/SmartMarkdown/issues/38).
